### PR TITLE
Make pip-grep and pip-pop compatible with pip 8.1.2

### DIFF
--- a/bin/pip-diff
+++ b/bin/pip-diff
@@ -38,6 +38,9 @@ class Requirements(object):
         finder = PackageFinder([], [], session=requests)
         for requirement in parse_requirements(reqfile, finder=finder, session=requests):
             if requirement.req:
+                if not getattr(requirement.req, 'name', None):
+                    # Prior to pip 8.1.2 the attribute `name` did not exist.
+                    requirement.req.name = requirement.req.project_name
                 self.requirements.append(requirement.req)
 
 
@@ -48,24 +51,24 @@ class Requirements(object):
 
         # Generate fresh packages.
         other_reqs = (
-            [r.project_name for r in r1.requirements]
+            [r.name for r in r1.requirements]
             if ignore_versions else r1.requirements
         )
 
         for req in r2.requirements:
-            r = req.project_name if ignore_versions else req
+            r = req.name if ignore_versions else req
 
             if r not in other_reqs and r not in excludes:
                 results['fresh'].append(req)
 
         # Generate stale packages.
         other_reqs = (
-            [r.project_name for r in r2.requirements]
+            [r.name for r in r2.requirements]
             if ignore_versions else r2.requirements
         )
 
         for req in r1.requirements:
-            r = req.project_name if ignore_versions else req
+            r = req.name if ignore_versions else req
 
             if r not in other_reqs and r not in excludes:
                 results['stale'].append(req)
@@ -88,11 +91,11 @@ def diff(r1, r2, include_fresh=False, include_stale=False, excludes=None):
 
     if include_fresh:
         for line in results['fresh']:
-            print(line.project_name if include_versions else line)
+            print(line.name if include_versions else line)
 
     if include_stale:
         for line in results['stale']:
-            print(line.project_name if include_versions else line)
+            print(line.name if include_versions else line)
 
 
 def main():

--- a/bin/pip-diff
+++ b/bin/pip-diff
@@ -18,6 +18,7 @@ from pip._vendor.requests import session
 
 requests = session()
 
+
 class Requirements(object):
     def __init__(self, reqfile=None):
         super(Requirements, self).__init__()
@@ -31,7 +32,6 @@ class Requirements(object):
         return '<Requirements \'{}\'>'.format(self.path)
 
     def load(self, reqfile):
-
         if not os.path.exists(reqfile):
             raise ValueError('The given requirements file does not exist.')
 
@@ -73,11 +73,7 @@ class Requirements(object):
         return results
 
 
-
-
-
 def diff(r1, r2, include_fresh=False, include_stale=False, excludes=None):
-
     include_versions = True if include_stale else False
     excludes = excludes if len(excludes) else []
 
@@ -99,7 +95,6 @@ def diff(r1, r2, include_fresh=False, include_stale=False, excludes=None):
             print(line.project_name if include_versions else line)
 
 
-
 def main():
     args = docopt(__doc__, version='pip-diff')
 
@@ -112,7 +107,6 @@ def main():
     }
 
     diff(**kwargs)
-
 
 
 if __name__ == '__main__':

--- a/bin/pip-grep
+++ b/bin/pip-grep
@@ -62,7 +62,7 @@ def grep(reqfile, packages, silent=False):
                 exit(0)
 
     if not silent:
-        print('Not found.'.format(requirement.req.project_name))
+        print('Not found.')
 
     exit(1)
 

--- a/bin/pip-grep
+++ b/bin/pip-grep
@@ -34,7 +34,11 @@ class Requirements(object):
 
         finder = PackageFinder([], [], session=requests)
         for requirement in parse_requirements(reqfile, finder=finder, session=requests):
-            self.requirements.append(requirement)
+            if requirement.req:
+                if not getattr(requirement.req, 'name', None):
+                    # Prior to pip 8.1.2 the attribute `name` did not exist.
+                    requirement.req.name = requirement.req.project_name
+                self.requirements.append(requirement.req)
 
 
 def grep(reqfile, packages, silent=False):
@@ -45,12 +49,11 @@ def grep(reqfile, packages, silent=False):
             print('There was a problem loading the given requirement file.')
         exit(os.EX_NOINPUT)
 
-    for requirement in r.requirements:
-        if requirement.req:
-            if requirement.req.project_name in packages:
-                if not silent:
-                    print('Package {} found!'.format(requirement.req.project_name))
-                exit(0)
+    for req in r.requirements:
+        if req.name in packages:
+            if not silent:
+                print('Package {} found!'.format(req.name))
+            exit(0)
 
     if not silent:
         print('Not found.')

--- a/bin/pip-grep
+++ b/bin/pip-grep
@@ -15,6 +15,7 @@ from pip._vendor.requests import session
 
 requests = session()
 
+
 class Requirements(object):
     def __init__(self, reqfile=None):
         super(Requirements, self).__init__()
@@ -28,7 +29,6 @@ class Requirements(object):
         return '<Requirements \'{}\'>'.format(self.path)
 
     def load(self, reqfile):
-
         if not os.path.exists(reqfile):
             raise ValueError('The given requirements file does not exist.')
 
@@ -37,28 +37,19 @@ class Requirements(object):
             self.requirements.append(requirement)
 
 
-
-
 def grep(reqfile, packages, silent=False):
-
     try:
         r = Requirements(reqfile)
     except ValueError:
-
         if not silent:
             print('There was a problem loading the given requirement file.')
-
         exit(os.EX_NOINPUT)
 
     for requirement in r.requirements:
-
         if requirement.req:
-
             if requirement.req.project_name in packages:
-
                 if not silent:
                     print('Package {} found!'.format(requirement.req.project_name))
-
                 exit(0)
 
     if not silent:
@@ -72,9 +63,7 @@ def main():
 
     kwargs = {'reqfile': args['<reqfile>'], 'packages': args['<package>'], 'silent': args['-s']}
 
-
     grep(**kwargs)
-
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
In pip 8.1.2 the type of `requirement.req` was changed, such that it now has a `name` attribute rather than `project_name`:
pypa/pip#3307

To fix this, a name attribute is added if missing, to try and avoid having to handle the varying attribute names repeatedly later on. (Whilst a tad hacky, it seemed like the least verbose solution for `pip-diff`. Both scripts could do with quite a bit of refactoring/de-duping of code, but that's fodder for another PR.)

Passes Travis when rebased on top of #11.

See individual commits for clearer diffs.

Fixes #10.